### PR TITLE
Fixed problem where recording is inverted by default.

### DIFF
--- a/vidmaker/__init__.py
+++ b/vidmaker/__init__.py
@@ -77,7 +77,7 @@ class Video:
         :param frame: next frame to be rendered
         :param inverted: if the colors are inverted set this value to true
         """
-        if inverted:
+        if not inverted:
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
         if self.auto_res:


### PR DESCRIPTION
When I create a pygame recording that uses Blue (#0000FF) as the main color, the recording saved shows Red (#FF0000). The line that I changed is the only one that could affect this as by default OpenCV records in BGR format, so it should always be converted to RGB, unless you want it to be inverted, which was originally not the case.


